### PR TITLE
fixed for reducers, better handling for being stateless

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -33,9 +33,9 @@ impl GraphBuilder {
         App {
             nodes: self.nodes,
             edges: self.edges,
-            add_messages: Arc::new(AddMessages),
-            append_outputs: Arc::new(AppendVec::<String>),
-            map_merge: Arc::new(MapMerge),
+            add_messages: &ADD_MESSAGES,
+            append_outputs: &APPEND_VEC,
+            map_merge: &MAP_MERGE,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use message::*;
-use node::*;
-use state::*;
+use graft::message::*;
+use graft::node::*;
+use graft::state::*;
 
 use tokio; // Ensure tokio is in your dependencies
 


### PR DESCRIPTION
Replaced generic PhantomData-based AppendVec<T> with zero-sized AppendVec.
Moved generic parameter to the impl (impl<T> Reducer<Vec<T>, Vec<T>> for AppendVec).
Added a small guard to skip extending with empty updates

Since reducers are stateless...
Added ADD_MESSAGES, APPEND_VEC, and MAP_MERGE static singletons in reducer.rs.
Updated App struct fields to use &'static references.
Updated GraphBuilder::compile to wire in the singletons.