### PR TITLE
Refactor App::apply_barrier to accept &mut VersionedState

### DIFF
--- a/src/reducers/append_vec.rs
+++ b/src/reducers/append_vec.rs
@@ -1,3 +1,4 @@
+#[expect(unused)]
 use crate::{node::NodePartial, state::VersionedState};
 
 // use super::Reducer;

--- a/src/reducers/map_merge.rs
+++ b/src/reducers/map_merge.rs
@@ -1,6 +1,5 @@
 use super::Reducer;
 use crate::{channels::Channel, node::NodePartial, state::VersionedState};
-use rustc_hash::FxHashMap as HashMap;
 
 #[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub struct MapMerge;


### PR DESCRIPTION
Update all internal logic to use &mut VersionedState directly (remove RwLock usage).
Update all call sites (including tests) to pass a mutable reference.